### PR TITLE
Add Beyblade catalog and episode viewer

### DIFF
--- a/data/beyblade.json
+++ b/data/beyblade.json
@@ -1,0 +1,308 @@
+[
+  {
+    "id": 1,
+    "title": "BeyBlade 01",
+    "url": "https://drive.google.com/file/d/1Et62Tliqm_7wmeafYvC9JTl8C13N-UaD/preview",
+    "thumbnail": "/bey01.webp"
+  },
+  {
+    "id": 2,
+    "title": "BeyBlade 02",
+    "url": "https://drive.google.com/file/d/1E-2AurGpjNTYkMhFR2oGG76dlBGvH5bj/preview",
+    "thumbnail": "/bey02.webp"
+  },
+  {
+    "id": 3,
+    "title": "BeyBlade 03",
+    "url": "https://drive.google.com/file/d/1vlaD7cEKW8LRGyLX7SBSW1hlSODBiBa1/preview",
+    "thumbnail": "/bey03.webp"
+  },
+  {
+    "id": 4,
+    "title": "BeyBlade 04",
+    "url": "https://drive.google.com/file/d/111UscO2D2sxQj27IV5imkde0wOM5Gqsn/preview",
+    "thumbnail": "/bey04.webp"
+  },
+  {
+    "id": 5,
+    "title": "BeyBlade 05",
+    "url": "https://drive.google.com/file/d/1C76di3DjQx0mr0x6gdnE30R2Lp-LCIyu/preview",
+    "thumbnail": "/bey05.webp"
+  },
+  {
+    "id": 6,
+    "title": "BeyBlade 06",
+    "url": "https://drive.google.com/file/d/1egdpS1srTjUL-Y-Ko2MJ3ZeMgR1kMxxO/preview",
+    "thumbnail": "/bey06.webp"
+  },
+  {
+    "id": 7,
+    "title": "BeyBlade 07",
+    "url": "https://drive.google.com/file/d/16g1IIUwOvb-0t9Yd8MwovMaCRagfbpGx/preview",
+    "thumbnail": "/bey07.webp"
+  },
+  {
+    "id": 8,
+    "title": "BeyBlade 08",
+    "url": "https://drive.google.com/file/d/1N_93B_rEVeIKgRSuSjkgQFCbFavWhyc_/preview",
+    "thumbnail": "/bey08.webp"
+  },
+  {
+    "id": 9,
+    "title": "BeyBlade 09",
+    "url": "https://drive.google.com/file/d/16CkipBJQrnFjkvirmRh3_DF9ss5jhN6z/preview",
+    "thumbnail": "/bey09.webp"
+  },
+  {
+    "id": 10,
+    "title": "BeyBlade 10",
+    "url": "https://drive.google.com/file/d/1hTgB6sHCwG-VvgheVxWx_-zzyvLZp-9h/preview",
+    "thumbnail": "/bey10.webp"
+  },
+  {
+    "id": 11,
+    "title": "BeyBlade 11",
+    "url": "https://drive.google.com/file/d/1Zo3vW3prHG0V41b7iN4CTZ5gfLsK1_H1/preview",
+    "thumbnail": "/bey11.webp"
+  },
+  {
+    "id": 12,
+    "title": "BeyBlade 12",
+    "url": "https://drive.google.com/file/d/16wVno_XCjdRbtEcCJ6jAjCJXrjl49d-_/preview",
+    "thumbnail": "/bey12.webp"
+  },
+  {
+    "id": 13,
+    "title": "BeyBlade 13",
+    "url": "https://drive.google.com/file/d/1alQCnx4KYj0wws42RIT1qZTJsWvs2CG4/preview",
+    "thumbnail": "/bey13.webp"
+  },
+  {
+    "id": 14,
+    "title": "BeyBlade 14",
+    "url": "https://drive.google.com/file/d/12_af1nX6j6mxQuU_nF8pLoGU3td6NtDf/preview",
+    "thumbnail": "/bey14.webp"
+  },
+  {
+    "id": 15,
+    "title": "BeyBlade 15",
+    "url": "https://drive.google.com/file/d/1MDs9gq-CwcVpcgZk0E3tNFi7boYyEtWC/preview",
+    "thumbnail": "/bey15.webp"
+  },
+  {
+    "id": 16,
+    "title": "BeyBlade 16",
+    "url": "https://drive.google.com/file/d/1GDc855PirGfZVUiZeWtnSpUwKY1NhLeD/preview",
+    "thumbnail": "/bey16.webp"
+  },
+  {
+    "id": 17,
+    "title": "BeyBlade 17",
+    "url": "https://drive.google.com/file/d/1ov31z5L9QDBQV_AmcwzxWU9o0fu-vCDB/preview",
+    "thumbnail": "/bey17.webp"
+  },
+  {
+    "id": 18,
+    "title": "BeyBlade 18",
+    "url": "https://drive.google.com/file/d/1TwsGpKbCc0SAnCqOVquFFSR5ML0ZXpG7/preview",
+    "thumbnail": "/bey18.webp"
+  },
+  {
+    "id": 19,
+    "title": "BeyBlade 19",
+    "url": "https://drive.google.com/file/d/16jv0DPQC5eNgfZ-j1p_ij9Bp5ACqY3cX/preview",
+    "thumbnail": "/bey19.webp"
+  },
+  {
+    "id": 20,
+    "title": "BeyBlade 20",
+    "url": "https://drive.google.com/file/d/1JNheMiqvK5XP9bNDewDCmYpWd_9IFDDI/preview",
+    "thumbnail": "/bey20.webp"
+  },
+  {
+    "id": 21,
+    "title": "BeyBlade 21",
+    "url": "https://drive.google.com/file/d/1AxXWQsqN1arkLXRMmMx_O_h4D6bZmkp3/preview",
+    "thumbnail": "/bey21.webp"
+  },
+  {
+    "id": 22,
+    "title": "BeyBlade 22",
+    "url": "https://drive.google.com/file/d/10aZ3ANaI1wl0SSxA8DxpbcgHzwqs3xuB/preview",
+    "thumbnail": "/bey22.webp"
+  },
+  {
+    "id": 23,
+    "title": "BeyBlade 23",
+    "url": "https://drive.google.com/file/d/1HcNrpSWJyGrdOkjlj7JAdcD5VZBpMngc/preview",
+    "thumbnail": "/bey23.webp"
+  },
+  {
+    "id": 24,
+    "title": "BeyBlade 24",
+    "url": "https://drive.google.com/file/d/1jwZklFEFDxxpju2YISvweO73glK2VIuP/preview",
+    "thumbnail": "/bey24.webp"
+  },
+  {
+    "id": 25,
+    "title": "BeyBlade 25",
+    "url": "https://drive.google.com/file/d/1vlxsdA9mWJapybyCObv0K5s6Fl6enRrW/preview",
+    "thumbnail": "/bey25.webp"
+  },
+  {
+    "id": 26,
+    "title": "BeyBlade 26",
+    "url": "https://drive.google.com/file/d/102VdVGZZETgcrqHmKW5NCWdvJhQsxjnd/preview",
+    "thumbnail": "/bey26.webp"
+  },
+  {
+    "id": 27,
+    "title": "BeyBlade 27",
+    "url": "https://drive.google.com/file/d/1laJ7veHY89eFzWPomxJNJm1fygrS3KKk/preview",
+    "thumbnail": "/bey27.webp"
+  },
+  {
+    "id": 28,
+    "title": "BeyBlade 28",
+    "url": "https://drive.google.com/file/d/1FnZ65Q5dHzOIa0uZhbWF_B2czhkgZfZd/preview",
+    "thumbnail": "/bey28.webp"
+  },
+  {
+    "id": 29,
+    "title": "BeyBlade 29",
+    "url": "https://drive.google.com/file/d/1CoCkctfsi5OdjY-_Hb1dz5QfkwnTF56K/preview",
+    "thumbnail": "/bey29.webp"
+  },
+  {
+    "id": 30,
+    "title": "BeyBlade 30",
+    "url": "https://drive.google.com/file/d/14ltKtgO9tJy2Tb7F9YuvU-JFA3yBUf29/preview",
+    "thumbnail": "/bey30.webp"
+  },
+  {
+    "id": 31,
+    "title": "BeyBlade 31",
+    "url": "https://drive.google.com/file/d/1CDo9GgvLmQcrUh70D61i5AjnfA-4NxHs/preview",
+    "thumbnail": "/bey31.webp"
+  },
+  {
+    "id": 32,
+    "title": "BeyBlade 32",
+    "url": "https://drive.google.com/file/d/1hTzfz8oGXYv9MrJxZepnZcrefhKxjsGJ/preview",
+    "thumbnail": "/bey32.webp"
+  },
+  {
+    "id": 33,
+    "title": "BeyBlade 33",
+    "url": "https://drive.google.com/file/d/1mwruUqsCJN40h4x9ayw29KemTlV1WnzE/preview",
+    "thumbnail": "/bey33.webp"
+  },
+  {
+    "id": 34,
+    "title": "BeyBlade 34",
+    "url": "https://drive.google.com/file/d/1OXo-4Y82Z6EOjL_1oKRRJwwJH6YlDIhp/preview",
+    "thumbnail": "/bey34.webp"
+  },
+  {
+    "id": 35,
+    "title": "BeyBlade 35",
+    "url": "https://drive.google.com/file/d/11udt5yASQMNyoj3ohWzRnC-jxm4KF5tv/preview",
+    "thumbnail": "/bey35.webp"
+  },
+  {
+    "id": 36,
+    "title": "BeyBlade 36",
+    "url": "https://drive.google.com/file/d/19FQZTyaYZOUWGGUTbihh6nxyLvJaQUZO/preview",
+    "thumbnail": "/bey36.webp"
+  },
+  {
+    "id": 37,
+    "title": "BeyBlade 37",
+    "url": "https://drive.google.com/file/d/1hHo6upCTp2MoLRO-ehDUxK_0Z6k2mlU9/preview",
+    "thumbnail": "/bey37.webp"
+  },
+  {
+    "id": 38,
+    "title": "BeyBlade 38",
+    "url": "https://drive.google.com/file/d/1fgaCq1PuLSDOoVz8rBXLlt9PH7nf69YQ/preview",
+    "thumbnail": "/bey38.webp"
+  },
+  {
+    "id": 39,
+    "title": "BeyBlade 39",
+    "url": "https://drive.google.com/file/d/1dR6EiHmyTZOKShlkSCAPQwuyjKsiu5U0/preview",
+    "thumbnail": "/bey39.webp"
+  },
+  {
+    "id": 40,
+    "title": "BeyBlade 40",
+    "url": "https://drive.google.com/file/d/12gypUh3sgoFF5PLWZeCyxdplO229RvC-/preview",
+    "thumbnail": "/bey40.webp"
+  },
+  {
+    "id": 41,
+    "title": "BeyBlade 41",
+    "url": "https://drive.google.com/file/d/1rHVqhQKQzcQsHCgYvBk98IzyIQF1m9-Q/preview",
+    "thumbnail": "/bey41.webp"
+  },
+  {
+    "id": 42,
+    "title": "BeyBlade 42",
+    "url": "https://drive.google.com/file/d/1ir3TvJfEtLoxxc6BTwLXCzQ_CSznVcxe/preview",
+    "thumbnail": "/bey42.webp"
+  },
+  {
+    "id": 43,
+    "title": "BeyBlade 43",
+    "url": "https://drive.google.com/file/d/1mZVMPj8tfVidnT61D8lLgZGOBPYsRHI3/preview",
+    "thumbnail": "/bey43.webp"
+  },
+  {
+    "id": 44,
+    "title": "BeyBlade 44",
+    "url": "https://drive.google.com/file/d/1IIo8tlha81Mx9GMLoGVemId6VhSU9oEx/preview",
+    "thumbnail": "/bey44.webp"
+  },
+  {
+    "id": 45,
+    "title": "BeyBlade 45",
+    "url": "https://drive.google.com/file/d/1DiZmqdc01BS6O_GeVjYGK39CBcX5ax9u/preview",
+    "thumbnail": "/bey45.webp"
+  },
+  {
+    "id": 46,
+    "title": "BeyBlade 46",
+    "url": "https://drive.google.com/file/d/1Oa6FLnIE2qP_SDzgthijEOE5xc0Q3DvM/preview",
+    "thumbnail": "/bey46.webp"
+  },
+  {
+    "id": 47,
+    "title": "BeyBlade 47",
+    "url": "https://drive.google.com/file/d/1LBUeN1hVmxA0t0xLKwkbwBEfW36lgcK_/preview",
+    "thumbnail": "/bey47.webp"
+  },
+  {
+    "id": 48,
+    "title": "BeyBlade 48",
+    "url": "https://drive.google.com/file/d/1foR-HB_5RoyHQvG5H6GGZnn7fNlTszae/preview",
+    "thumbnail": "/bey48.webp"
+  },
+  {
+    "id": 49,
+    "title": "BeyBlade 49",
+    "url": "https://drive.google.com/file/d/1xcmlPMt7y24iR4miHnc6Cdn5i6AwQg-Q/preview",
+    "thumbnail": "/bey49.webp"
+  },
+  {
+    "id": 50,
+    "title": "BeyBlade 50",
+    "url": "https://drive.google.com/file/d/1HkNLtyHN-1gqHJFso_WKSUg8tbOPJ8Z-/preview",
+    "thumbnail": "/bey50.webp"
+  },
+  {
+    "id": 51,
+    "title": "BeyBlade 51",
+    "url": "https://drive.google.com/file/d/18DMY9FcjD_cvvYV3hwPMcvqqNjYRDli6/preview",
+    "thumbnail": "/bey51.webp"
+  }
+]

--- a/pages/baybade/index.js
+++ b/pages/baybade/index.js
@@ -1,20 +1,24 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import episodes from "../data/episodes.json";
-import styles from "../styles/Home.module.css";
+import episodes from "../../data/beyblade.json";
+import styles from "../../styles/Home.module.css";
 
-export default function Home() {
+const STORAGE_KEY = "vistos_baybade";
+const PLACEHOLDER_THUMB = "/beyblade-placeholder.svg";
+const BANNER_IMAGE = "/beyblade-header.svg";
+
+export default function BeybladePage() {
   const [vistos, setVistos] = useState([]);
   const router = useRouter();
 
   useEffect(() => {
-    const storage = JSON.parse(localStorage.getItem("vistos") || "[]");
+    const storage = JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]");
     setVistos(storage);
   }, []);
 
   const toggleVisto = (id, e) => {
-    e.stopPropagation(); // no dispares la navegación
+    e.stopPropagation();
     let updated;
     if (vistos.includes(id)) {
       updated = vistos.filter((ep) => ep !== id);
@@ -22,45 +26,47 @@ export default function Home() {
       updated = [...vistos, id];
     }
     setVistos(updated);
-    localStorage.setItem("vistos", JSON.stringify(updated));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
   };
 
   const handleCardClick = (id) => {
-    // al abrir un episodio se marca como visto automáticamente
     if (!vistos.includes(id)) {
       const updated = [...vistos, id];
       setVistos(updated);
-      localStorage.setItem("vistos", JSON.stringify(updated));
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
     }
-    router.push(`/ver/${id}`);
+    router.push(`/baybade/ver/${id}`);
   };
 
   const borrarProgreso = () => {
-    localStorage.removeItem("vistos");
+    localStorage.removeItem(STORAGE_KEY);
     setVistos([]);
   };
 
   const progreso = Math.round((vistos.length / episodes.length) * 100);
-  const bannerImg = "/header.jpg";
+
+  const handleImgError = (event) => {
+    event.currentTarget.onerror = null;
+    event.currentTarget.src = PLACEHOLDER_THUMB;
+  };
 
   return (
     <div className={styles.container}>
-      {/* --- HERO HEADER --- */}
       <header
         className={styles.hero}
-        style={{ backgroundImage: `url(${bannerImg})` }}
+        style={{ backgroundImage: `url(${BANNER_IMAGE})` }}
       >
         <div className={styles.overlay}>
           <div className={styles.switchRow}>
-            <Link href="/baybade" className={styles.switchBtn}>
-              Ver Beyblade en castellano →
+            <Link href="/" className={styles.switchBtn}>
+              ← Volver a Digimon Adventure
             </Link>
           </div>
 
-          <h1 className={styles.title}>Digimon Adventure</h1>
+          <h1 className={styles.title}>Beyblade (Castellano)</h1>
 
           <p className={styles.subtitle}>
-            Sigue tu progreso y revive la primera temporada completa.
+            Marca tu progreso y disfruta de los 51 episodios clásicos.
           </p>
 
           <div className={styles.progressWrapper}>
@@ -84,7 +90,6 @@ export default function Home() {
         </div>
       </header>
 
-      {/* --- GRID DE EPISODIOS --- */}
       <main className={styles.grid}>
         {episodes.map((ep) => (
           <div
@@ -100,11 +105,10 @@ export default function Home() {
           >
             <div className={styles.thumbWrapper}>
               <img
-                src={
-                  ep.thumbnail || `/mini${String(ep.id).padStart(2, "0")}.webp`
-                }
+                src={ep.thumbnail}
                 alt={ep.title}
                 className={styles.thumbnail}
+                onError={handleImgError}
               />
 
               <div className={styles.hoverOverlay}>

--- a/pages/baybade/ver/[id].js
+++ b/pages/baybade/ver/[id].js
@@ -1,0 +1,232 @@
+import { useRouter } from "next/router";
+import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import episodes from "../../../data/beyblade.json";
+import styles from "../../../styles/Episode.module.css";
+
+const STORAGE_KEY = "vistos_baybade";
+
+/** ===== Utilidades Google Drive ===== **/
+function extractDriveId(rawUrl = "") {
+  try {
+    const m1 = rawUrl.match(/\/file\/d\/([^/]+)\//);
+    if (m1?.[1]) return m1[1];
+    const u = new URL(rawUrl);
+    const qid = u.searchParams.get("id");
+    if (qid) return qid;
+    const m2 = rawUrl.match(/[?&]id=([^&]+)/);
+    if (m2?.[1]) return m2[1];
+  } catch {}
+  return null;
+}
+function buildDriveCandidates(id) {
+  return [
+    `https://drive.usercontent.google.com/uc?id=${id}&export=download`,
+    `https://drive.google.com/uc?export=download&id=${id}`,
+    `https://lh3.googleusercontent.com/uc?export=download&id=${id}`,
+  ];
+}
+function buildDrivePreviewUrl(id) {
+  return `https://drive.google.com/file/d/${id}/preview`;
+}
+
+const INTRO_END = 92;
+const SKIP_INTRO_TO = INTRO_END;
+const SKIP_RECAP_TO = 125;
+const RECAP_END = 125;
+
+export default function VerBeyblade() {
+  const router = useRouter();
+  const { id, autoplay: autoplayQuery } = router.query;
+  const episodeId = Number(id);
+
+  const episode = useMemo(
+    () => episodes.find((e) => e.id === episodeId),
+    [episodeId]
+  );
+  const prev = useMemo(
+    () => episodes.find((e) => e.id === episodeId - 1),
+    [episodeId]
+  );
+  const next = useMemo(
+    () => episodes.find((e) => e.id === episodeId + 1),
+    [episodeId]
+  );
+
+  useEffect(() => {
+    if (!episodeId) return;
+    const vistos = JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]");
+    if (!vistos.includes(episodeId)) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([...vistos, episodeId]));
+    }
+  }, [episodeId]);
+
+  const shouldAutoplay = String(autoplayQuery) === "1";
+  const driveId = useMemo(
+    () => (episode ? extractDriveId(episode.url) : null),
+    [episode]
+  );
+  const candidates = useMemo(
+    () => (driveId ? buildDriveCandidates(driveId) : []),
+    [driveId]
+  );
+  const previewSrc = driveId
+    ? buildDrivePreviewUrl(driveId)
+    : episode?.url || "";
+
+  const [srcIndex, setSrcIndex] = useState(0);
+  const [useIframePreview, setUseIframePreview] = useState(false);
+  const videoRef = useRef(null);
+
+  const [showSkipIntro, setShowSkipIntro] = useState(true);
+  const [showSkipRecap, setShowSkipRecap] = useState(false);
+
+  useEffect(() => {
+    setSrcIndex(0);
+    setUseIframePreview(false);
+    setShowSkipIntro(true);
+    setShowSkipRecap(false);
+  }, [episodeId]);
+
+  useEffect(() => {
+    const v = videoRef.current;
+    if (!v || useIframePreview) return;
+
+    const onCanPlay = async () => {
+      setShowSkipIntro(true);
+      setShowSkipRecap(false);
+
+      if (shouldAutoplay) {
+        try {
+          v.muted = true;
+          await v.play();
+        } catch {}
+      }
+    };
+
+    const onTimeUpdate = () => {
+      const t = v.currentTime || 0;
+      if (t >= INTRO_END) setShowSkipIntro(false);
+      if (t >= INTRO_END && t < RECAP_END) setShowSkipRecap(true);
+      else if (t >= RECAP_END) setShowSkipRecap(false);
+    };
+
+    v.addEventListener("canplay", onCanPlay);
+    v.addEventListener("timeupdate", onTimeUpdate);
+    return () => {
+      v.removeEventListener("canplay", onCanPlay);
+      v.removeEventListener("timeupdate", onTimeUpdate);
+    };
+  }, [srcIndex, shouldAutoplay, useIframePreview]);
+
+  const handleVideoError = () => {
+    if (srcIndex < candidates.length - 1) {
+      setSrcIndex((i) => i + 1);
+    } else {
+      setUseIframePreview(true);
+    }
+  };
+
+  const handleEnded = () => {
+    if (next) router.push(`/baybade/ver/${next.id}?autoplay=1`);
+  };
+
+  const goPrev = () => prev && router.push(`/baybade/ver/${prev.id}`);
+  const goNext = () => next && router.push(`/baybade/ver/${next.id}?autoplay=1`);
+
+  const skipTo = (seconds) => {
+    const v = videoRef.current;
+    if (!v) return;
+    try {
+      v.currentTime = seconds;
+      v.play().catch(() => {});
+    } catch {}
+  };
+
+  if (!episode) {
+    return (
+      <div className={styles.container}>
+        <h1>Episodio no encontrado</h1>
+        <Link href="/baybade">Volver al listado</Link>
+      </div>
+    );
+  }
+
+  const currentSrc = candidates[srcIndex];
+
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        <Link href="/baybade" className={styles.back}>
+          ← Volver a la lista
+        </Link>
+        <h1>{episode.title}</h1>
+      </header>
+
+      <div className={styles.videoWrapper}>
+        {!useIframePreview && currentSrc ? (
+          <video
+            key={currentSrc}
+            ref={videoRef}
+            src={currentSrc}
+            controls
+            autoPlay={shouldAutoplay}
+            muted
+            playsInline
+            onEnded={handleEnded}
+            onError={handleVideoError}
+            className={styles.videoEl}
+          />
+        ) : (
+          <iframe
+            key={previewSrc}
+            src={previewSrc}
+            allow="autoplay"
+            allowFullScreen
+            loading="lazy"
+            title={episode.title}
+            className={styles.iframeEl}
+          />
+        )}
+
+        {!useIframePreview && currentSrc && (
+          <>
+            {showSkipRecap && (
+              <button
+                className={`${styles.skipBtn} ${styles.skipTop}`}
+                onClick={() => skipTo(SKIP_RECAP_TO)}
+                title="Saltar resumen"
+              >
+                ⏭ Saltar resumen
+              </button>
+            )}
+            {showSkipIntro && (
+              <button
+                className={`${styles.skipBtn} ${styles.skipBelow}`}
+                onClick={() => skipTo(SKIP_INTRO_TO)}
+                title="Saltar intro"
+              >
+                ⏭ Saltar intro
+              </button>
+            )}
+          </>
+        )}
+      </div>
+
+      {useIframePreview && (
+        <p className={styles.iframeNotice}>
+          Este reproductor no permite saltar intro ni resumen.
+        </p>
+      )}
+
+      <div className={styles.nav}>
+        <button className={styles.navBtn} onClick={goPrev} disabled={!prev}>
+          ⬅ Anterior
+        </button>
+        <button className={styles.navBtn} onClick={goNext} disabled={!next}>
+          Siguiente ➡
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/public/beyblade-header.svg
+++ b/public/beyblade-header.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#050b24" />
+      <stop offset="45%" stop-color="#0a2a52" />
+      <stop offset="100%" stop-color="#ffb703" />
+    </linearGradient>
+  </defs>
+  <rect width="1920" height="1080" fill="url(#bg)" />
+  <g fill="#ffffff" fill-opacity="0.1">
+    <circle cx="320" cy="260" r="180" />
+    <circle cx="1560" cy="360" r="220" />
+    <circle cx="960" cy="740" r="260" />
+    <circle cx="1220" cy="160" r="140" />
+  </g>
+  <g stroke="#ffffff" stroke-opacity="0.18" stroke-width="6" fill="none">
+    <circle cx="420" cy="780" r="140" />
+    <circle cx="1480" cy="760" r="190" />
+  </g>
+</svg>

--- a/public/beyblade-placeholder.svg
+++ b/public/beyblade-placeholder.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180">
+  <defs>
+    <linearGradient id="thumb" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="55%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#60a5fa" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="180" rx="18" fill="url(#thumb)" />
+  <g fill="#ffffff" fill-opacity="0.15">
+    <circle cx="70" cy="60" r="42" />
+    <circle cx="250" cy="80" r="58" />
+    <circle cx="150" cy="130" r="48" />
+  </g>
+  <text
+    x="50%"
+    y="52%"
+    dominant-baseline="middle"
+    text-anchor="middle"
+    font-family="'Segoe UI', 'Inter', sans-serif"
+    font-size="32"
+    font-weight="700"
+    fill="#ffffff"
+    fill-opacity="0.9"
+  >
+    Beyblade
+  </text>
+</svg>

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -37,6 +37,46 @@
   text-shadow: 0 2px 10px rgba(0, 0, 0, 0.9);
 }
 
+.subtitle {
+  font-size: 1.1rem;
+  color: #f5f5f5;
+  margin-bottom: 18px;
+  letter-spacing: 0.3px;
+}
+
+.switchRow {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 16px;
+}
+
+.switchBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #ffffff;
+  padding: 8px 16px;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  transition: background 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.35);
+}
+
+.switchBtn:hover {
+  background: rgba(0, 0, 0, 0.75);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.55);
+}
+
+.switchBtn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px #e50914, 0 10px 26px rgba(0, 0, 0, 0.55);
+}
+
 /* --- PROGRESO --- */
 .progressWrapper {
   margin: 0 auto 16px auto;


### PR DESCRIPTION
## Summary
- add a Beyblade listing page with independent progress tracking and thumbnail fallbacks
- implement a dedicated Beyblade episode viewer that reuses the Google Drive fallback logic
- include the Beyblade episode dataset plus themed header and placeholder artwork

## Testing
- npm run lint *(fails because Next.js prompts to create an ESLint config interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68cf688d63848323848ffb51d66b991a