### PR TITLE
Add search input for Digimon episode header

### DIFF
--- a/components/SeriesListPage.js
+++ b/components/SeriesListPage.js
@@ -19,6 +19,7 @@ export default function SeriesListPage({
 }) {
   const router = useRouter();
   const [seenEpisodes, setSeenEpisodes] = useState([]);
+  const [searchTerm, setSearchTerm] = useState("");
 
   const legacySignature = legacyStorageKeys.join("|");
 
@@ -62,6 +63,20 @@ export default function SeriesListPage({
     return Math.round((seenEpisodes.length / episodes.length) * 100);
   }, [episodes, seenEpisodes]);
 
+  const normalizedSearch = searchTerm.trim().toLowerCase();
+
+  const filteredEpisodes = useMemo(() => {
+    if (!normalizedSearch) return episodes;
+
+    return episodes.filter((episode) =>
+      episode.title.toLowerCase().includes(normalizedSearch)
+    );
+  }, [episodes, normalizedSearch]);
+
+  const handleSearchChange = useCallback((event) => {
+    setSearchTerm(event.target.value);
+  }, []);
+
   return (
     <div className={styles.container}>
       <header
@@ -82,6 +97,20 @@ export default function SeriesListPage({
           {hero.subtitle ? (
             <p className={styles.subtitle}>{hero.subtitle}</p>
           ) : null}
+
+          <div className={styles.searchWrapper}>
+            <label className={styles.searchLabel} htmlFor="episode-search">
+              Buscar capítulo
+            </label>
+            <input
+              id="episode-search"
+              type="search"
+              value={searchTerm}
+              onChange={handleSearchChange}
+              placeholder="Escribe el nombre del capítulo"
+              className={styles.searchInput}
+            />
+          </div>
 
           <div className={styles.progressWrapper}>
             <div
@@ -108,7 +137,13 @@ export default function SeriesListPage({
       </header>
 
       <main className={styles.grid}>
-        {episodes.map((episode) => {
+        {filteredEpisodes.length === 0 ? (
+          <p className={styles.emptyState}>
+            No se encontraron capítulos con ese nombre.
+          </p>
+        ) : null}
+
+        {filteredEpisodes.map((episode) => {
           const thumbnailSrc = getEpisodeThumbnail(episode);
           const seen = seenEpisodes.includes(episode.id);
 

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -44,6 +44,44 @@
   letter-spacing: 0.3px;
 }
 
+.searchWrapper {
+  margin: 0 auto 20px auto;
+  width: 100%;
+  max-width: 520px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.searchLabel {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #f0f0f0;
+}
+
+.searchInput {
+  width: 100%;
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  padding: 10px 18px;
+  color: #fff;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.searchInput::placeholder {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: rgba(229, 9, 20, 0.7);
+  box-shadow: 0 0 0 3px rgba(229, 9, 20, 0.25);
+  background: rgba(0, 0, 0, 0.75);
+}
+
 .switchRow {
   display: flex;
   justify-content: flex-end;
@@ -147,6 +185,13 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
   gap: 24px;
+}
+
+.emptyState {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: #d0d0d0;
+  font-size: 1.05rem;
 }
 
 /* --- CARD --- */


### PR DESCRIPTION
## Summary
- add a search field to the series header to filter episodes by title
- style the new search control and empty state message within the grid

## Testing
- `npm run lint` *(fails: prompts to configure ESLint interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68dc24464ff88323a2919e25e494a338