### PR TITLE
Enhance home page hero and featured sections

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,22 +1,53 @@
 import Link from "next/link";
 import styles from "@/styles/Landing.module.css";
 
+const featuredCollections = [
+  {
+    slug: "digimon",
+    title: "Digimon Adventure",
+    description:
+      "Revive las aventuras digitales de Tai, Agumon y el resto de los Niños Elegidos en el Digimundo.",
+    accent: "orange",
+  },
+  {
+    slug: "beyblade",
+    title: "Beyblade",
+    description:
+      "Siente la emoción de los combates entre peonzas y acompaña a Tyson y sus amigos en cada torneo.",
+    accent: "blue",
+  },
+];
+
 export default function Home() {
   return (
     <div className={styles.container}>
-      <main className={styles.panel}>
-        <h1 className={styles.title}>Series en castellano</h1>
-        <p className={styles.subtitle}>
-          Elige la colección que quieres continuar viendo o descubrir.
-        </p>
-        <div className={styles.actions}>
-          <Link href="/digimon" className={styles.buttonPrimary}>
-            Digimon Adventure
-          </Link>
-          <Link href="/beyblade" className={styles.buttonSecondary}>
-            Beyblade
-          </Link>
-        </div>
+      <main className={styles.content}>
+        <section className={styles.hero}>
+          <h1 className={styles.title}>Series en castellano</h1>
+          <p className={styles.subtitle}>
+            Tu catálogo de series y películas clásicas dobladas al castellano, organizado y listo para maratonear.
+          </p>
+        </section>
+
+        <section className={styles.sections}>
+          <h2 className={styles.sectionHeading}>Explora las colecciones disponibles</h2>
+          <div className={styles.grid}>
+            {featuredCollections.map((collection) => (
+              <article
+                key={collection.slug}
+                className={`${styles.card} ${styles[collection.accent]}`}
+              >
+                <div className={styles.cardHeader}>
+                  <h3 className={styles.cardTitle}>{collection.title}</h3>
+                </div>
+                <p className={styles.cardDescription}>{collection.description}</p>
+                <Link href={`/${collection.slug}`} className={styles.cardLink}>
+                  Ver colección
+                </Link>
+              </article>
+            ))}
+          </div>
+        </section>
       </main>
     </div>
   );

--- a/styles/Landing.module.css
+++ b/styles/Landing.module.css
@@ -1,73 +1,150 @@
 .container {
   min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem;
-  background: radial-gradient(circle at top, #2b4c7e, #0f172a);
+  padding: clamp(3rem, 5vw, 5rem) clamp(1.5rem, 4vw, 4rem);
+  background: radial-gradient(circle at top, #1e3a8a, #0f172a 65%);
   color: #f8fafc;
-  text-align: center;
+  display: flex;
+  justify-content: center;
 }
 
-.panel {
-  max-width: 560px;
-  width: 100%;
-  background: rgba(15, 23, 42, 0.75);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: 24px;
-  padding: 3rem 2.5rem;
-  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.45);
-  backdrop-filter: blur(12px);
+.content {
+  width: min(1080px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(3rem, 5vw, 5rem);
+}
+
+.hero {
+  text-align: center;
+  display: grid;
+  gap: 1.5rem;
 }
 
 .title {
   font-size: clamp(2.5rem, 5vw, 3.5rem);
   font-weight: 700;
-  margin-bottom: 1rem;
+  letter-spacing: -0.02em;
 }
 
 .subtitle {
-  font-size: 1.125rem;
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
   color: #cbd5f5;
-  margin-bottom: 2.5rem;
+  max-width: 680px;
+  margin: 0 auto;
+  line-height: 1.7;
 }
 
-.actions {
+.sections {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 28px;
+  padding: clamp(2rem, 4vw, 3rem);
+  box-shadow: 0 32px 64px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(14px);
+}
+
+.sectionHeading {
+  font-size: clamp(1.5rem, 3vw, 1.9rem);
+  font-weight: 600;
+  text-align: center;
+  margin-bottom: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.grid {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+  position: relative;
+  padding: 1.75rem;
+  border-radius: 24px;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
   display: grid;
   gap: 1rem;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
 }
 
-.buttonPrimary,
-.buttonSecondary {
-  display: inline-flex;
+.card::after {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  z-index: -1;
+  opacity: 0.45;
+  transition: opacity 0.25s ease;
+}
+
+.cardHeader {
+  display: flex;
   align-items: center;
-  justify-content: center;
-  padding: 0.9rem 1.5rem;
-  border-radius: 14px;
+  gap: 0.75rem;
+}
+
+.cardTitle {
+  font-size: 1.35rem;
   font-weight: 600;
+}
+
+.cardDescription {
+  color: #e2e8f0;
+  line-height: 1.65;
+  font-size: 0.98rem;
+}
+
+.cardLink {
+  justify-self: flex-start;
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.buttonPrimary {
+.cardLink:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 35px rgba(14, 165, 233, 0.3);
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 30px 50px rgba(15, 23, 42, 0.4);
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.card:hover::after {
+  opacity: 0.75;
+}
+
+.orange::after {
+  background: linear-gradient(135deg, rgba(249, 115, 22, 0.5), rgba(251, 191, 36, 0.25));
+}
+
+.orange .cardLink {
   background: linear-gradient(135deg, #fbbf24, #f97316);
   color: #0f172a;
-  box-shadow: 0 20px 40px rgba(249, 115, 22, 0.35);
+  box-shadow: 0 16px 32px rgba(249, 115, 22, 0.35);
 }
 
-.buttonSecondary {
+.blue::after {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.5), rgba(56, 189, 248, 0.25));
+}
+
+.blue .cardLink {
   background: linear-gradient(135deg, #38bdf8, #3b82f6);
   color: white;
-  box-shadow: 0 20px 40px rgba(59, 130, 246, 0.35);
+  box-shadow: 0 16px 32px rgba(59, 130, 246, 0.35);
 }
 
-.buttonPrimary:hover,
-.buttonSecondary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
-}
+@media (max-width: 600px) {
+  .sections {
+    padding: 1.75rem;
+  }
 
-.buttonPrimary:focus,
-.buttonSecondary:focus {
-  outline: 3px solid rgba(148, 163, 184, 0.4);
-  outline-offset: 4px;
+  .card {
+    padding: 1.5rem;
+  }
 }


### PR DESCRIPTION
## Summary
- redesign the home page hero with a clearer slogan and supporting copy
- add reusable featured collections data to present each series with description and link
- refresh landing page styles with responsive card grid and accent states for each collection

## Testing
- not run (next lint prompts for configuration)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb4d95cd483239a35b98360007f2c)