### PR TITLE
Add Monster Hunter Stories series to catalogue

### DIFF
--- a/data/monster-hunter-stories.json
+++ b/data/monster-hunter-stories.json
@@ -1,0 +1,132 @@
+[
+  {
+    "id": 1,
+    "title": "Episodio 01",
+    "url": "https://drive.google.com/file/d/1OHmIy4taGsns8H7eNLY0wt7B0lXUwtln/preview"
+  },
+  {
+    "id": 2,
+    "title": "Episodio 02",
+    "url": "https://drive.google.com/file/d/1uDcbf7IuWfmT0_4Bemqp2yk6NZzY_ouE/preview"
+  },
+  {
+    "id": 3,
+    "title": "Episodio 03",
+    "url": "https://drive.google.com/file/d/1rANdqqW9W0BrRdul78M8qhdybsTp7WFJ/preview"
+  },
+  {
+    "id": 4,
+    "title": "Episodio 04",
+    "url": "https://drive.google.com/file/d/1SimRFiCcIbwZZzJ7Fse2uU6p2ju3XrYm/preview"
+  },
+  {
+    "id": 5,
+    "title": "Episodio 05",
+    "url": "https://drive.google.com/file/d/1_lwIu_XFX1tOYi1YKRxiFxYTKCjOGvlG/preview"
+  },
+  {
+    "id": 6,
+    "title": "Episodio 06",
+    "url": "https://drive.google.com/file/d/1MSh64PWIjNIY4GEImEGm0KQKZ-nXpuPW/preview"
+  },
+  {
+    "id": 7,
+    "title": "Episodio 07",
+    "url": "https://drive.google.com/file/d/1AjRuPhf_30EKgnmLU-CUiS44SFk5k2dh/preview"
+  },
+  {
+    "id": 8,
+    "title": "Episodio 08",
+    "url": "https://drive.google.com/file/d/19Asl1iQdbR4mnIMcBSgR8Cw1ZQecQoo7/preview"
+  },
+  {
+    "id": 9,
+    "title": "Episodio 09",
+    "url": "https://drive.google.com/file/d/1TqItrpd_JXxr8-KvR6ulsCvdgKbZEKvL/preview"
+  },
+  {
+    "id": 10,
+    "title": "Episodio 10",
+    "url": "https://drive.google.com/file/d/1ib2Oww7YdZ7nV7nwMaTE66WI2JNJ40-i/preview"
+  },
+  {
+    "id": 11,
+    "title": "Episodio 11",
+    "url": "https://drive.google.com/file/d/1Ebd5YNg8utthyuCLmDJjJvPp3VSeR/preview"
+  },
+  {
+    "id": 12,
+    "title": "Episodio 12",
+    "url": "https://drive.google.com/file/d/11dPs58r_hJdTOOQM0AVkXXZ2Y_iYx4FA/preview"
+  },
+  {
+    "id": 13,
+    "title": "Episodio 13",
+    "url": "https://drive.google.com/file/d/1tUIvyljzu-LYkLrUs7BSM1-VceQUPL5r/preview"
+  },
+  {
+    "id": 14,
+    "title": "Episodio 14",
+    "url": "https://drive.google.com/file/d/1IibZEIEmmXAWpyhztkb73LTOasxt8MLQ/preview"
+  },
+  {
+    "id": 15,
+    "title": "Episodio 15",
+    "url": "https://drive.google.com/file/d/1NP9AirmJKxLsmrV9GMyyTGM34i7WG_d8/preview"
+  },
+  {
+    "id": 16,
+    "title": "Episodio 16",
+    "url": "https://drive.google.com/file/d/1J58AkUBD8qcYSkC9UTnAt224rXmaifRd/preview"
+  },
+  {
+    "id": 17,
+    "title": "Episodio 17",
+    "url": "https://drive.google.com/file/d/1FLvNgO4UdcnVJzOeDf19pqXeC7cs6xvz/preview"
+  },
+  {
+    "id": 18,
+    "title": "Episodio 18",
+    "url": "https://drive.google.com/file/d/14WEhVSsO1jVREsgTqODeLo1kmQydwmbx/preview"
+  },
+  {
+    "id": 19,
+    "title": "Episodio 19",
+    "url": "https://drive.google.com/file/d/1jFg--bqubNAcqq--EO_VlWw2_2Ogj_2J/preview"
+  },
+  {
+    "id": 20,
+    "title": "Episodio 20",
+    "url": "https://drive.google.com/file/d/1dM-ikcxgFZ-6dFg0g71kAfBtoopJnA61/preview"
+  },
+  {
+    "id": 21,
+    "title": "Episodio 21",
+    "url": "https://drive.google.com/file/d/1v9OZ7Rq8EsL_cSEpXKCa13n4MSR2vuf7/preview"
+  },
+  {
+    "id": 22,
+    "title": "Episodio 22",
+    "url": "https://drive.google.com/file/d/1plXf-jrq1NCn8qEFOiM_VxzZD7pOpwYs/preview"
+  },
+  {
+    "id": 23,
+    "title": "Episodio 23",
+    "url": "https://drive.google.com/file/d/19kg59-ErsSMsUruTcp_eH9bG3NOIL0hg/preview"
+  },
+  {
+    "id": 24,
+    "title": "Episodio 24",
+    "url": "https://drive.google.com/file/d/1lXK2R6LNGl9D2w-2ZRgytHJ5iT05Drre/preview"
+  },
+  {
+    "id": 25,
+    "title": "Episodio 25",
+    "url": "https://drive.google.com/file/d/1Q3qYfclobfgZZ2qWhwCsiRAn6u5noC1O/preview"
+  },
+  {
+    "id": 26,
+    "title": "Episodio 26",
+    "url": "https://drive.google.com/file/d/1POOhWwN0uMFeCAK7oPn-UFwP-5O9xZy9/preview"
+  }
+]

--- a/pages/index.js
+++ b/pages/index.js
@@ -16,6 +16,13 @@ const featuredCollections = [
       "Siente la emoción de los combates entre peonzas y acompaña a Tyson y sus amigos en cada torneo.",
     accent: "blue",
   },
+  {
+    slug: "monster-hunter-stories",
+    title: "Monster Hunter Stories",
+    description:
+      "Únete a los Riders y sus Monsties para explorar el mundo y forjar vínculos legendarios.",
+    accent: "purple",
+  },
 ];
 
 export default function Home() {

--- a/pages/monster-hunter-stories/index.js
+++ b/pages/monster-hunter-stories/index.js
@@ -1,0 +1,38 @@
+import SeriesListPage from "@/components/SeriesListPage";
+import episodes from "@/data/monster-hunter-stories.json";
+import Link from "next/link";
+
+const STORAGE_KEY = "vistos_monster_hunter_stories";
+const PLACEHOLDER_THUMB = "/monster-hunter-stories-placeholder.svg";
+
+const HERO_CONFIG = {
+  title: "Monster Hunter Stories",
+  subtitle:
+    "Acompaña a Lute y su Rathalos en una aventura llena de vínculos y batallas inolvidables.",
+  bannerImage: "/monster-hunter-stories-banner.svg",
+};
+
+const getThumbnail = (episode) => episode.thumbnail || PLACEHOLDER_THUMB;
+
+const handleThumbnailError = (event) => {
+  event.currentTarget.onerror = null;
+  event.currentTarget.src = PLACEHOLDER_THUMB;
+};
+
+export default function MonsterHunterStoriesPage() {
+  return (
+    <>
+      <Link href="/" className="back-link">
+        ← Volver al inicio
+      </Link>
+      <SeriesListPage
+        episodes={episodes}
+        storageKey={STORAGE_KEY}
+        basePath="/monster-hunter-stories"
+        hero={HERO_CONFIG}
+        getEpisodeThumbnail={getThumbnail}
+        onThumbnailError={handleThumbnailError}
+      />
+    </>
+  );
+}

--- a/pages/monster-hunter-stories/ver/[id].js
+++ b/pages/monster-hunter-stories/ver/[id].js
@@ -1,0 +1,16 @@
+import EpisodePlayerPage from "@/components/EpisodePlayerPage";
+import episodes from "@/data/monster-hunter-stories.json";
+
+const STORAGE_KEY = "vistos_monster_hunter_stories";
+
+export default function MonsterHunterStoriesEpisodePage() {
+  return (
+    <EpisodePlayerPage
+      episodes={episodes}
+      storageKey={STORAGE_KEY}
+      basePath="/monster-hunter-stories"
+      backHref="/monster-hunter-stories"
+      backLabel="← Volver a Monster Hunter Stories"
+    />
+  );
+}

--- a/public/monster-hunter-stories-banner.svg
+++ b/public/monster-hunter-stories-banner.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 600" role="img" aria-labelledby="title desc">
+  <title id="title">Banner Monster Hunter Stories</title>
+  <desc id="desc">Fondo degradado con silueta de montañas y un jinete sobre un monstruo.</desc>
+  <defs>
+    <linearGradient id="sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#1d2c4f" />
+      <stop offset="60%" stop-color="#352658" />
+      <stop offset="100%" stop-color="#4a1f48" />
+    </linearGradient>
+    <linearGradient id="mountain" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#251b3b" />
+      <stop offset="100%" stop-color="#382145" />
+    </linearGradient>
+  </defs>
+  <rect width="1440" height="600" fill="url(#sky)" />
+  <g fill="#ffffff" opacity="0.06">
+    <circle cx="180" cy="140" r="80" />
+    <circle cx="1320" cy="200" r="120" />
+    <circle cx="960" cy="120" r="90" />
+  </g>
+  <path d="M0 440 L160 420 L320 450 L480 420 L640 470 L800 430 L960 450 L1120 420 L1280 440 L1440 410 L1440 600 L0 600 Z" fill="url(#mountain)" />
+  <path d="M760 360 q40 -80 120 -60 q40 10 80 -10 q-20 60 -60 90 q-40 30 -60 90 q-40 -70 -80 -90 q-30 -15 -60 -10 q40 -40 60 -100 z" fill="#1b1028" opacity="0.8" />
+  <path d="M850 310 q30 -40 60 -30 q20 10 30 30 q-20 10 -30 40 q-10 30 -40 30 q-10 -40 -20 -70 z" fill="#150c20" opacity="0.8" />
+</svg>

--- a/public/monster-hunter-stories-placeholder.svg
+++ b/public/monster-hunter-stories-placeholder.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Monster Hunter Stories Placeholder</title>
+  <desc id="desc">Imagen de relleno con fondo degradado morado y texto centrado.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1b2d4f" />
+      <stop offset="100%" stop-color="#4f2d6e" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)" />
+  <g fill="#ffffff" font-family="'Montserrat', 'Helvetica Neue', Arial, sans-serif" text-anchor="middle">
+    <text x="320" y="188" font-size="48" font-weight="600" letter-spacing="4">
+      MONSTER HUNTER
+    </text>
+    <text x="320" y="244" font-size="44" font-weight="500" letter-spacing="6">
+      STORIES
+    </text>
+  </g>
+</svg>

--- a/styles/Landing.module.css
+++ b/styles/Landing.module.css
@@ -139,6 +139,20 @@
   box-shadow: 0 16px 32px rgba(59, 130, 246, 0.35);
 }
 
+.purple::after {
+  background: linear-gradient(
+    135deg,
+    rgba(139, 92, 246, 0.55),
+    rgba(236, 72, 153, 0.25)
+  );
+}
+
+.purple .cardLink {
+  background: linear-gradient(135deg, #ec4899, #8b5cf6);
+  color: white;
+  box-shadow: 0 16px 32px rgba(139, 92, 246, 0.35);
+}
+
 @media (max-width: 600px) {
   .sections {
     padding: 1.75rem;


### PR DESCRIPTION
## Summary
- add Monster Hunter Stories to the landing collections with a dedicated purple accent style
- include the episode listing and player routes backed by the provided Google Drive links
- add branded banner and thumbnail placeholder artwork for the new series

## Testing
- not run (npm run lint prompts for initial configuration)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fba2adc7c8323b459f41f1b4510c0)