### PR TITLE
Add Spanish movie collection

### DIFF
--- a/components/SeriesListPage.js
+++ b/components/SeriesListPage.js
@@ -8,6 +8,21 @@ function defaultThumbnailResolver(episode) {
   return episode.thumbnail || "";
 }
 
+const defaultProgressFormatter = (seenCount, totalCount) =>
+  `${seenCount} / ${totalCount} episodios vistos`;
+
+const defaultCardAriaLabel = (episode) =>
+  `Reproducir episodio ${episode.id}: ${episode.title}`;
+
+const defaultRenderEpisodeTitle = (episode) =>
+  `${episode.id}. ${episode.title}`;
+
+const defaultToggleButtonLabel = (isSeen) =>
+  isSeen ? "Visto" : "Marcar visto";
+
+const defaultToggleButtonAriaLabel = (isSeen) =>
+  isSeen ? "Marcar como no visto" : "Marcar como visto";
+
 export default function SeriesListPage({
   episodes,
   storageKey,
@@ -16,6 +31,15 @@ export default function SeriesListPage({
   hero,
   getEpisodeThumbnail = defaultThumbnailResolver,
   onThumbnailError,
+  searchLabel = "Buscar capítulo",
+  searchPlaceholder = "Escribe el nombre del capítulo",
+  emptyStateMessage = "No se encontraron capítulos con ese nombre.",
+  resetButtonLabel = "Borrar progreso",
+  progressFormatter = defaultProgressFormatter,
+  cardAriaLabel = defaultCardAriaLabel,
+  renderEpisodeTitle = defaultRenderEpisodeTitle,
+  toggleButtonLabel = defaultToggleButtonLabel,
+  toggleButtonAriaLabel = defaultToggleButtonAriaLabel,
 }) {
   const router = useRouter();
   const [seenEpisodes, setSeenEpisodes] = useState([]);
@@ -100,14 +124,14 @@ export default function SeriesListPage({
 
           <div className={styles.searchWrapper}>
             <label className={styles.searchLabel} htmlFor="episode-search">
-              Buscar capítulo
+              {searchLabel}
             </label>
             <input
               id="episode-search"
               type="search"
               value={searchTerm}
               onChange={handleSearchChange}
-              placeholder="Escribe el nombre del capítulo"
+              placeholder={searchPlaceholder}
               className={styles.searchInput}
             />
           </div>
@@ -123,7 +147,7 @@ export default function SeriesListPage({
               />
             </div>
             <p className={styles.progressText}>
-              {seenEpisodes.length} / {episodes.length} episodios vistos
+              {progressFormatter(seenEpisodes.length, episodes.length)}
             </p>
           </div>
 
@@ -131,7 +155,7 @@ export default function SeriesListPage({
             onClick={() => updateProgress([])}
             className={styles.resetBtn}
           >
-            Borrar progreso
+            {resetButtonLabel}
           </button>
         </div>
       </header>
@@ -139,7 +163,7 @@ export default function SeriesListPage({
       <main className={styles.grid}>
         {filteredEpisodes.length === 0 ? (
           <p className={styles.emptyState}>
-            No se encontraron capítulos con ese nombre.
+            {emptyStateMessage}
           </p>
         ) : null}
 
@@ -162,7 +186,7 @@ export default function SeriesListPage({
               role="button"
               tabIndex={0}
               onKeyDown={handleKeyDown}
-              aria-label={`Reproducir episodio ${episode.id}: ${episode.title}`}
+              aria-label={cardAriaLabel(episode)}
             >
               <div className={styles.thumbWrapper}>
                 <img
@@ -180,16 +204,16 @@ export default function SeriesListPage({
               </div>
 
               <h2 className={styles.epTitle}>
-                {episode.id}. {episode.title}
+                {renderEpisodeTitle(episode)}
               </h2>
 
               <button
                 className={`${styles.vistoBtn} ${seen ? styles.vistoActivo : ""}`}
                 onClick={(event) => handleToggleSeen(episode.id, event)}
                 aria-pressed={seen}
-                aria-label={seen ? "Marcar como no visto" : "Marcar como visto"}
+                aria-label={toggleButtonAriaLabel(seen)}
               >
-                {seen ? "Visto" : "Marcar visto"}
+                {toggleButtonLabel(seen)}
               </button>
             </div>
           );

--- a/data/peliculas.json
+++ b/data/peliculas.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": 1,
+    "title": "Goofy e hijo",
+    "url": "https://mega.nz/embed/ekNESD4J#QVKFDEsK0DNsXEqtJlBUapcpB8BKWypO9pc_4H5S5y4"
+  },
+  {
+    "id": 2,
+    "title": "La gran aventura de Mortadelo y Filemón",
+    "url": "https://drive.google.com/file/d/1sXGedhxZMpD_rlX8CzlT3Hcb7IhItoX7/preview"
+  },
+  {
+    "id": 3,
+    "title": "Los reyes magos",
+    "url": "https://drive.google.com/file/d/1yxalTMEEv5BPXpQsnlGovqzbA0yFBLem/preview"
+  },
+  {
+    "id": 4,
+    "title": "Shaolin Soccer",
+    "url": "https://drive.google.com/file/d/1jlRnJGArWX7h5O5z-VCZd_vyFcX4E1j4/preview"
+  },
+  {
+    "id": 5,
+    "title": "Super Mario Bros",
+    "url": "https://drive.google.com/file/d/1bSBT6aYklxAdHa1AL43li5sQXWBvRTWp/preview"
+  },
+  {
+    "id": 6,
+    "title": "Tekken - The Animation Movie",
+    "url": "https://drive.google.com/file/d/1jR7hvdVw0D5rk5Kf5hyoTpXJ4VNzcHyN/preview"
+  },
+  {
+    "id": 7,
+    "title": "Una película de Minecraft (2025)",
+    "url": "https://drive.google.com/file/d/1ZDsV1vKkmee8IHGwe9EQW5v7YheKAgJa/preview"
+  },
+  {
+    "id": 8,
+    "title": "Aquí llega Condemor el pecador de la pradera (1996)",
+    "url": "https://drive.google.com/file/d/1IdeuQ20o7NDJRRqQcT-8Ls7JTAR0usFI/preview"
+  },
+  {
+    "id": 9,
+    "title": "Bracula: Condemor II HD (1997)",
+    "url": "https://drive.google.com/file/d/1ynfzWu5-TIH4zRk7ot6817LZyBmepwjY/preview"
+  }
+]

--- a/pages/index.js
+++ b/pages/index.js
@@ -23,6 +23,13 @@ const featuredCollections = [
       "Únete a los Riders y sus Monsties para explorar el mundo y forjar vínculos legendarios.",
     accent: "purple",
   },
+  {
+    slug: "peliculas",
+    title: "Colección de películas",
+    description:
+      "Clásicos animados, comedias españolas y rarezas dobladas al castellano listas para tu próxima sesión cine.",
+    accent: "teal",
+  },
 ];
 
 export default function Home() {

--- a/pages/peliculas/index.js
+++ b/pages/peliculas/index.js
@@ -1,0 +1,52 @@
+import SeriesListPage from "@/components/SeriesListPage";
+import movies from "@/data/peliculas.json";
+import Link from "next/link";
+
+const STORAGE_KEY = "vistos_peliculas";
+const MOVIE_PLACEHOLDER = "/movies-placeholder.svg";
+
+const HERO_CONFIG = {
+  title: "Colección de películas",
+  subtitle:
+    "Anímate a maratonear clásicos familiares, comedias españolas y anime doblado al castellano.",
+  bannerImage: "/movies-banner.svg",
+};
+
+const LIST_LABELS = {
+  searchLabel: "Buscar película",
+  searchPlaceholder: "Escribe el título de la película",
+  emptyStateMessage: "No se encontraron películas con ese nombre.",
+  resetButtonLabel: "Borrar progreso",
+  progressFormatter: (seen, total) => `${seen} / ${total} películas vistas`,
+  cardAriaLabel: (movie) => `Reproducir película ${movie.title}`,
+  renderEpisodeTitle: (movie) => movie.title,
+  toggleButtonLabel: (seen) => (seen ? "Vista" : "Marcar vista"),
+  toggleButtonAriaLabel: (seen) =>
+    seen ? "Marcar película como no vista" : "Marcar película como vista",
+};
+
+const getMovieThumbnail = (movie) => movie.thumbnail || MOVIE_PLACEHOLDER;
+
+const handleThumbnailError = (event) => {
+  event.currentTarget.onerror = null;
+  event.currentTarget.src = MOVIE_PLACEHOLDER;
+};
+
+export default function PeliculasPage() {
+  return (
+    <>
+      <Link href="/" className="back-link">
+        ← Volver al inicio
+      </Link>
+      <SeriesListPage
+        episodes={movies}
+        storageKey={STORAGE_KEY}
+        basePath="/peliculas"
+        hero={HERO_CONFIG}
+        getEpisodeThumbnail={getMovieThumbnail}
+        onThumbnailError={handleThumbnailError}
+        {...LIST_LABELS}
+      />
+    </>
+  );
+}

--- a/pages/peliculas/ver/[id].js
+++ b/pages/peliculas/ver/[id].js
@@ -1,0 +1,18 @@
+import EpisodePlayerPage from "@/components/EpisodePlayerPage";
+import movies from "@/data/peliculas.json";
+
+const STORAGE_KEY = "vistos_peliculas";
+
+export default function PeliculaPlayerPage() {
+  return (
+    <EpisodePlayerPage
+      episodes={movies}
+      storageKey={STORAGE_KEY}
+      basePath="/peliculas"
+      backHref="/peliculas"
+      backLabel="← Volver a Películas"
+      notFoundLabel="Película no encontrada"
+      resumeNotice="Este reproductor puede tardar unos segundos en cargar. Si falla, abre el enlace original en una pestaña nueva."
+    />
+  );
+}

--- a/public/movies-banner.svg
+++ b/public/movies-banner.svg
@@ -1,0 +1,37 @@
+<svg width="1440" height="600" viewBox="0 0 1440 600" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="bg" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(720 -120) rotate(90) scale(720 1100)">
+      <stop offset="0" stop-color="#1d4ed8" stop-opacity="0.75" />
+      <stop offset="1" stop-color="#020617" />
+    </radialGradient>
+    <linearGradient id="light" x1="240" y1="80" x2="1200" y2="520" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fbbf24" stop-opacity="0.32" />
+      <stop offset="1" stop-color="#f97316" stop-opacity="0.08" />
+    </linearGradient>
+    <linearGradient id="beam" x1="480" y1="160" x2="960" y2="440" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#38bdf8" stop-opacity="0.4" />
+      <stop offset="1" stop-color="#a855f7" stop-opacity="0.2" />
+    </linearGradient>
+  </defs>
+  <rect width="1440" height="600" fill="url(#bg)" />
+  <ellipse cx="720" cy="560" rx="520" ry="120" fill="#0f172a" opacity="0.65" />
+  <rect x="280" y="160" width="880" height="320" rx="48" fill="#0f172a" opacity="0.55" />
+  <rect x="320" y="200" width="800" height="240" rx="36" fill="#1f2937" opacity="0.7" />
+  <rect x="320" y="200" width="800" height="240" rx="36" fill="url(#light)" />
+  <path d="M520 220h400c22.091 0 40 17.909 40 40v80c0 22.091-17.909 40-40 40H520c-22.091 0-40-17.909-40-40v-80c0-22.091 17.909-40 40-40z" fill="#020617" opacity="0.85" />
+  <path d="M540 260c0-11.046 8.954-20 20-20h160c11.046 0 20 8.954 20 20v80c0 11.046-8.954 20-20 20H560c-11.046 0-20-8.954-20-20v-80z" fill="#111827" />
+  <path d="M740 260l120 60-120 60v-120z" fill="#38bdf8" opacity="0.85" />
+  <path d="M480 220l200-120 200 120-200 120-200-120z" fill="url(#beam)" opacity="0.8" />
+  <g opacity="0.35" stroke="#38bdf8" stroke-width="2">
+    <circle cx="340" cy="220" r="20" />
+    <circle cx="1100" cy="240" r="18" />
+    <circle cx="360" cy="360" r="24" />
+    <circle cx="1080" cy="360" r="22" />
+  </g>
+  <text x="720" y="160" text-anchor="middle" fill="#f8fafc" font-size="64" font-weight="600" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" opacity="0.95">
+    Cinemateca retro en castellano
+  </text>
+  <text x="720" y="220" text-anchor="middle" fill="#e2e8f0" font-size="28" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" opacity="0.85">
+    Clásicos familiares, comedia española y anime listo para maratonear
+  </text>
+</svg>

--- a/public/movies-placeholder.svg
+++ b/public/movies-placeholder.svg
@@ -1,0 +1,23 @@
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradient" x1="0" y1="0" x2="640" y2="360" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0f172a" />
+      <stop offset="1" stop-color="#1e3a8a" />
+    </linearGradient>
+    <linearGradient id="badge" x1="160" y1="60" x2="480" y2="300" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#f97316" stop-opacity="0.85" />
+      <stop offset="1" stop-color="#fbbf24" stop-opacity="0.85" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" rx="32" fill="url(#gradient)" />
+  <rect x="120" y="80" width="400" height="200" rx="28" fill="url(#badge)" opacity="0.9" />
+  <path d="M276 144c0-8.837 7.163-16 16-16h56c8.837 0 16 7.163 16 16v72c0 8.837-7.163 16-16 16h-56c-8.837 0-16-7.163-16-16v-72z" stroke="#0f172a" stroke-width="8" fill="none" />
+  <path d="M364 168l40 24-40 24v-48z" fill="#0f172a" />
+  <circle cx="208" cy="128" r="20" fill="#f8fafc" opacity="0.2" />
+  <circle cx="432" cy="108" r="16" fill="#f8fafc" opacity="0.2" />
+  <circle cx="192" cy="240" r="24" fill="#f8fafc" opacity="0.2" />
+  <circle cx="452" cy="244" r="22" fill="#f8fafc" opacity="0.2" />
+  <text x="320" y="312" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" opacity="0.85">
+    Próximamente en tu maratón
+  </text>
+</svg>

--- a/styles/Landing.module.css
+++ b/styles/Landing.module.css
@@ -153,6 +153,20 @@
   box-shadow: 0 16px 32px rgba(139, 92, 246, 0.35);
 }
 
+.teal::after {
+  background: linear-gradient(
+    135deg,
+    rgba(45, 212, 191, 0.5),
+    rgba(56, 189, 248, 0.25)
+  );
+}
+
+.teal .cardLink {
+  background: linear-gradient(135deg, #22d3ee, #14b8a6);
+  color: #0f172a;
+  box-shadow: 0 16px 32px rgba(20, 184, 166, 0.35);
+}
+
 @media (max-width: 600px) {
   .sections {
     padding: 1.75rem;


### PR DESCRIPTION
## Summary
- allow SeriesListPage to customise copy, aria labels, and rendering so it can serve collections other than episodic series
- add a new movies dataset, listing page, and player route with placeholder artwork for each film entry
- surface the movies collection on the landing page with dedicated accent styling and artwork assets

## Testing
- npm run lint *(fails: command prompts for initial ESLint configuration)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fbee6547083239f62a0b2ad57696a)